### PR TITLE
Encapsulating image specs for multithread support.

### DIFF
--- a/heatmap/heatmap.c
+++ b/heatmap/heatmap.c
@@ -3,14 +3,17 @@
 #include <math.h>
 #include <string.h>
 
-float MIN_X = 0;
-float MIN_Y = 0;
-float MAX_X = 0;
-float MAX_Y = 0;
+struct info
+{
+	float minX;
+	float minY;
+	float maxX;
+	float maxY;
 
-int WIDTH = 0;
-int HEIGHT = 0;
-int DOTSIZE = 0;
+	int width;
+	int height;
+	int dotsize;
+};
 
 struct point {
     float x;
@@ -30,15 +33,15 @@ BOOL WINAPI DllMain(    HINSTANCE hinstDLL,  // handle to DLL module
 #endif
 
 //walk the list of points, get the boundary values    
-void getBounds(float *points, unsigned int cPoints)
+void getBounds(struct info *inf, float *points, unsigned int cPoints)
 {
     unsigned int i = 0;
 
     // first init the global counts
-    MIN_X = points[i];
-    MIN_Y = points[i+1];
-    MAX_X = points[i];
-    MAX_Y = points[i+1];
+    float minX = points[i];
+    float minY = points[i+1];
+    float maxX = points[i];
+    float maxY = points[i+1];
 
     //then iterate over the list and find the max/min values
     for(i = 0; i < cPoints; i=i+2)
@@ -46,35 +49,52 @@ void getBounds(float *points, unsigned int cPoints)
         float x = points[i];
         float y = points[i+1];
 
-        if (x > MAX_X) MAX_X = x;
-        if (x < MIN_X) MIN_X = x;
+        if (x > maxX) maxX = x;
+        if (x < minX) minX = x;
 
-        if (y > MAX_Y) MAX_Y = y;
-        if (y < MIN_Y) MIN_Y = y;
+        if (y > maxY) maxY = y;
+        if (y < minY) minY = y;
     }
+    
+    inf->minX = minX;
+    inf->minY = minY;
+    inf->maxX = maxX;
+    inf->maxY = maxY;
 
     return;
 }
 
 //transform from dataset coordinates into image coordinates
-struct point translate(struct point pt)
+struct point translate(struct info *inf, struct point pt)
 {
+    float minX = inf->minX;
+    float minY = inf->minY;
+    float maxX = inf->maxX;
+    float maxY = inf->maxY;
+    
+    int width = inf->width;
+    int height = inf->height;
+       
     // normalize the point into range 0..1
-    pt.x = (pt.x - MIN_X) / (MAX_X - MIN_X);
-    pt.y = (pt.y - MIN_Y) / (MAX_Y - MIN_Y);
+    pt.x = (pt.x - minX) / (maxX - minX);
+    pt.y = (pt.y - minY) / (maxY - minY);
 
     //and then map into our image dimentions.
-    pt.x = (pt.x * WIDTH);
-    pt.y = ((1-pt.y) * HEIGHT);
+    pt.x = (pt.x * width);
+    pt.y = ((1-pt.y) * height);
 
     return pt;
 }
 
-unsigned char* calcDensity(float *points, int cPoints)
+unsigned char* calcDensity(struct info *inf, float *points, int cPoints)
 {
-    unsigned char* pixels = (unsigned char *)calloc(WIDTH*HEIGHT, sizeof(char)); 
+    int width = inf->width;
+    int height = inf->height;
+    int dotsize = inf->dotsize;
+    
+    unsigned char* pixels = (unsigned char *)calloc(width*height, sizeof(char)); 
 
-    float midpt = DOTSIZE / 2.f;
+    float midpt = dotsize / 2.f;
     double radius = sqrt(midpt*midpt + midpt*midpt) / 2.f;
     double dist = 0.0;
     int pixVal = 0;
@@ -85,7 +105,7 @@ unsigned char* calcDensity(float *points, int cPoints)
     struct point pt = {0};  
 
     // initialize image data to white
-    for(i = 0; i < (int)WIDTH*HEIGHT; i++) 
+    for(i = 0; i < (int)width*height; i++) 
     {
         pixels[i] = 0xff;
     }
@@ -94,21 +114,21 @@ unsigned char* calcDensity(float *points, int cPoints)
     {
         pt.x = points[i];
         pt.y = points[i+1];
-        pt = translate(pt);
+        pt = translate(inf, pt);
 
         for (j = (int)pt.x - midpt; j < (int)pt.x + midpt; j++)
         {   
             for (k = (int)(pt.y - midpt); k < (int)(pt.y + midpt); k++)
             {
-                if (j < 0 || k < 0 || j >= WIDTH || k >= HEIGHT) continue; 
+                if (j < 0 || k < 0 || j >= width || k >= height) continue; 
 
                 dist = sqrt( (j-pt.x)*(j-pt.x) + (k-pt.y)*(k-pt.y) );
 
                 pixVal = (int)(200.0*(dist/radius)+50.0);
                 if (pixVal > 255) pixVal = 255;
 
-                ndx = k*WIDTH + j;
-                if(ndx >= (int)WIDTH*HEIGHT) continue;   // ndx can be greater than array bounds
+                ndx = k*width + j;
+                if(ndx >= (int)width*height) continue;   // ndx can be greater than array bounds
 
                 #ifdef DEBUG
                 printf("pt.x: %.2f pt.y: %.2f j: %d k: %d ndx: %d\n", pt.x, pt.y, j, k, ndx);
@@ -122,15 +142,19 @@ unsigned char* calcDensity(float *points, int cPoints)
     return pixels;
 }
 
-unsigned char *colorize(unsigned char* pixels_bw, int *scheme, unsigned char* pixels_color, 
+unsigned char *colorize(struct info *inf, unsigned char* pixels_bw, int *scheme, unsigned char* pixels_color, 
               int opacity)
 {
+    int width = inf->width;
+    int height = inf->height;
+    int dotsize = inf->dotsize;
+    
     int i = 0;
     int pix = 0;
     int highCount = 0;
     int alpha = opacity;
 
-    for(i = 0; i < (int)WIDTH*HEIGHT; i++)
+    for(i = 0; i < (int)width*height; i++)
     {
         pix = pixels_bw[i];
 
@@ -146,7 +170,7 @@ unsigned char *colorize(unsigned char* pixels_bw, int *scheme, unsigned char* pi
         pixels_color[i*4+3] = alpha;
     } 
     
-    if (highCount > WIDTH*HEIGHT*0.8)
+    if (highCount > width*height*0.8)
     {   
         fprintf(stderr, "Warning: 80%% of output pixels are over 95%% density.\n");
         fprintf(stderr, "Decrease dotsize or increase output image resolution?\n");
@@ -177,33 +201,34 @@ unsigned char *tx(float *points,
         fprintf(stderr, "Invalid parameter; aborting.\n");
         return NULL;
     }
-        
-
-    DOTSIZE = dotsize;
-    WIDTH = w;
-    HEIGHT = h;
+    
+    struct info inf = {0};
+    
+    inf.dotsize = dotsize;
+    inf.width = w;
+    inf.height = h;
  
     // get min/max x/y values from point list
     if (boundsOverride == 1)
     {
-        MAX_X = maxX; MIN_X = minX;
-        MAX_Y = maxY; MIN_Y = minY;
+        inf.maxX = maxX; inf.minX = minX;
+        inf.maxY = maxY; inf.minY = minY;
     }
     else
     {
-        getBounds(points, cPoints);
+        getBounds(&inf, points, cPoints);
     }
 
     #ifdef DEBUG
-    printf("min: (%.2f, %.2f) max: (%.2f, %.2f)\n", MIN_X, MIN_Y, MAX_X, MAX_Y);
+    printf("min: (%.2f, %.2f) max: (%.2f, %.2f)\n", inf.minX, inf.minY, inf.maxX, inf.maxY);
     #endif
 
     //iterate through points, place a dot at each center point
     //and set pix value from 0 - 255 using multiply method for radius [dotsize].
-    pixels_bw = calcDensity(points, cPoints);
+    pixels_bw = calcDensity(&inf, points, cPoints);
 
     //using provided color scheme and opacity, update pixel value to RGBA values
-    pix_color = colorize(pixels_bw, scheme, pix_color, opacity);
+    pix_color = colorize(&inf, pixels_bw, scheme, pix_color, opacity);
 
     free(pixels_bw);
     pixels_bw = NULL;


### PR DESCRIPTION
The area and image size are moved into a struct so they can be local to the method instead of the whole shared library... which can get called from multiple threads. This resolves issue #18.
